### PR TITLE
Ap view all cats

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -2,6 +2,8 @@ import React from "react"
 import { Route } from "react-router-dom"
 import { PostProvider } from "./posts/PostProvider"
 import { PostList } from "./posts/PostList"
+import { CategoryList } from "./category/CategoryList"
+import { CategoryProvider } from "./category/CategoryProvider"
 
 export const ApplicationViews = () => {
     return <>
@@ -14,6 +16,11 @@ export const ApplicationViews = () => {
                     <PostList />
                 </Route>
             </PostProvider>
+            <CategoryProvider>
+                <Route path="/categories">
+                    <CategoryList />
+                </Route>
+            </CategoryProvider>
 
 
 

--- a/src/components/category/Category.css
+++ b/src/components/category/Category.css
@@ -1,0 +1,4 @@
+.category_card {
+    border: 1px solid black;
+    padding: 1em
+}

--- a/src/components/category/CategoryList.js
+++ b/src/components/category/CategoryList.js
@@ -20,6 +20,7 @@ export const CategoryList = () => {
                     </div>
                 )}
             </div>
+            <div>(=ↀωↀ=)✧</div>
         </>
     )
 }

--- a/src/components/category/CategoryList.js
+++ b/src/components/category/CategoryList.js
@@ -1,0 +1,25 @@
+import React, { useContext, useEffect } from "react"
+import { CategoryContext } from "./CategoryProvider"
+import "./Category.css"
+
+export const CategoryList = () => {
+    const { categories, getCategories } = useContext(CategoryContext)
+
+
+    useEffect(() => {
+            getCategories()
+    }, [])
+    const sortedCats = categories.sort((a, b) => a.label > b.label ? 1 : -1)
+    
+    return (
+        <>
+            <div>
+                {sortedCats.map(c =>
+                    <div className="category_card" key={c.id}>
+                        <p><b>label: </b>{c.label}</p>
+                    </div>
+                )}
+            </div>
+        </>
+    )
+}

--- a/src/components/category/CategoryProvider.js
+++ b/src/components/category/CategoryProvider.js
@@ -1,0 +1,23 @@
+import React, { useState } from "react"
+
+export const CategoryContext = React.createContext()
+
+export const CategoryProvider = (props) => {
+    const [categories, setCategories] = useState([])
+
+    const getCategories = () => {
+        return fetch("http://localhost:8088/categories")
+            .then(res => res.json())
+            .then(setCategories)
+    }
+
+
+
+    return (
+        <CategoryContext.Provider value={{
+            categories, getCategories
+        }}>
+            {props.children}
+        </CategoryContext.Provider>
+    )
+}

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -25,7 +25,7 @@ export const NavBar = () => {
                 <Link className="navbar__link" to="/">Tag MGMT</Link>
             </li>
             <li className="navbar__item">
-                <Link className="navbar__link" to="/">Category MGMT</Link>
+                <Link className="navbar__link" to="/categories">Category MGMT</Link>
             </li>
             <li className="navbar__item">
                 <Link className="navbar__link" to="/">User Profiles</Link>


### PR DESCRIPTION
# Description

user on client side can select category MGMT from dom and will be routed to categories path were all cats will be displayed in alphabetical order

Fixes # (11)

## Type of change
Feat.

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)

- [x] This change requires a documentation update

# Testing Instructions

`git fetch --all`
`git checkout ap-viewAllCats`

go to client side webpage and select category mgmt

make sure you have categories in your database!!!


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
